### PR TITLE
close overlay on modal close

### DIFF
--- a/src/app/shadcn/DialogDemo.tsx
+++ b/src/app/shadcn/DialogDemo.tsx
@@ -13,14 +13,17 @@ import { Input } from "./input";
 import React from "react";
 import { AngularWrapper } from "@bubblydoo/angular-react";
 import { TooltipPreviewComponent } from "../dialog/tooltip";
+import { TooltipDemo } from "./TooltipDemo";
 
 export function DialogDemo() {
+  const [open, setOpen] = React.useState(false);
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button variant="outline">React dialog</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[425px]" onOverlayClick={() => setOpen(false)}>
         <DialogHeader>
           <DialogTitle>Edit profile</DialogTitle>
           <DialogDescription>
@@ -28,6 +31,7 @@ export function DialogDemo() {
           </DialogDescription>
 
           <AngularWrapper component={TooltipPreviewComponent} />
+          <TooltipDemo />
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">

--- a/src/app/shadcn/dialog.tsx
+++ b/src/app/shadcn/dialog.tsx
@@ -28,14 +28,18 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps
+	extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {onOverlayClick: () => void}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, onOverlayClick, children, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay onPointerDownCapture={() => onOverlayClick()} />
     <DialogPrimitive.Content
       ref={ref}
+      onPointerDownOutside={(event) => event.preventDefault()}
       className={hlm(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,


### PR DESCRIPTION
Fixes React dialogs closing on Angular tooltip click by disabling onPointerDownOutside events on content and adding a onPointerDownCapture in DialogOverlay

Pros:

- No modification of Radix

Cons:

- Requires an extra callback in DialogContent to manually close the overlay open state

Why? The dialog context is in Radix, I can't figure out any way to get directly to the context outside of the Radix dialog code.